### PR TITLE
Bugfix: discovery flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:8.5-jdk17 AS build
 WORKDIR /app
 
-COPY build.gradle settings.gradle gradlew gradle/ ./
+COPY build.gradle settings.gradle ./
 RUN gradle dependencies --no-daemon || true
 
 COPY . .
@@ -13,4 +13,4 @@ WORKDIR /app
 COPY --from=build /app/build/libs/*-SNAPSHOT.jar app.jar
 
 EXPOSE 8082
-ENTRYPOINT ["java", "-jar", "app.jar", "--spring.data.mongodb.host=mongodb"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,12 +29,12 @@ services:
     ports:
       - '27017:27017'
     volumes:
-      - mongodb_data:/data/db
+      - mongodb_vol:/data/db
     networks:
       - docker_network
 
 volumes:
-  mongodb_data:
+  mongodb_vol:
 
 networks:
   docker_network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,17 +11,12 @@ services:
     depends_on:
       - mongodb
     environment:
-      SPRING_DATA_MONGODB_HOST: mongodb
+      SPRING_DATA_MONGODB_HOST: host.docker.internal
       SPRING_DATA_MONGODB_PORT: 27017
     networks:
       - docker_network
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    deploy:
-      resources:
-        limits:
-          cpus: '0.5'
-          memory: 512M
 
   mongodb:
     image: mongodb/mongodb-community-server:latest

--- a/src/main/java/in/nha/abdm/wrapper/v3/database/mongo/services/PatientV3Service.java
+++ b/src/main/java/in/nha/abdm/wrapper/v3/database/mongo/services/PatientV3Service.java
@@ -84,17 +84,17 @@ public class PatientV3Service {
    * @param careContexts List of careContext to update the status.
    */
   public void updateCareContext(
-      String patientReference, List<CareContext> careContexts, String hipId)
+      String abhaAddress, String patientReference, List<CareContext> careContexts, String hipId)
       throws IllegalDataStateException {
     Query query =
         new Query(
-            Criteria.where(FieldIdentifiers.PATIENT_REFERENCE)
-                .is(patientReference)
+            Criteria.where(FieldIdentifiers.ABHA_ADDRESS)
+                .is(abhaAddress)
                 .and(FieldIdentifiers.HIP_ID)
                 .is(hipId));
     Patient patient = mongoTemplate.findOne(query, Patient.class);
     if (Objects.isNull(patient)) {
-      throw new IllegalDataStateException("Patient not found in database: " + patientReference);
+      throw new IllegalDataStateException("Patient not found in database: " + abhaAddress);
     }
     if (patient.getCareContexts() == null) {
       Update update = new Update().set(FieldIdentifiers.CARE_CONTEXTS, careContexts);
@@ -102,34 +102,30 @@ public class PatientV3Service {
       return;
     }
     Update update = new Update().addToSet(FieldIdentifiers.CARE_CONTEXTS).each(careContexts);
-    log.info(
-        "updateCareContextStatus: patientReference: "
-            + patientReference
-            + " careContexts: "
-            + careContexts);
+    log.info("updateCareContext: abhaAddress: " + abhaAddress + " careContexts: " + careContexts);
     this.mongoTemplate.updateFirst(query, update, Patient.class);
   }
 
   public void updateCareContextStatus(
-      String patientReference, List<CareContext> careContexts, String hipId) {
+      String abhaAddress, List<CareContext> careContexts, String hipId) {
     Query query =
         new Query(
-            Criteria.where(FieldIdentifiers.PATIENT_REFERENCE)
-                .is(patientReference)
+            Criteria.where(FieldIdentifiers.ABHA_ADDRESS)
+                .is(abhaAddress)
                 .and(FieldIdentifiers.HIP_ID)
                 .is(hipId));
 
     Patient patient = this.mongoTemplate.findOne(query, Patient.class);
 
     if (patient == null) {
-      log.error("Patient not found with reference: {} and facility: {}", patientReference, hipId);
+      log.error("Patient not found with abhaAddress: {} and facility: {}", abhaAddress, hipId);
       return;
     }
 
     List<CareContext> existingCareContexts = patient.getCareContexts();
 
     if (existingCareContexts == null) {
-      log.info("No care contexts found for patient reference: {}", patientReference);
+      log.info("No care contexts found for abhaAddress: {}", abhaAddress);
       return;
     }
 
@@ -145,10 +141,7 @@ public class PatientV3Service {
     this.mongoTemplate.updateFirst(query, update, Patient.class);
 
     log.info(
-        "updateCareContextStatus: patientReference: "
-            + patientReference
-            + " careContexts: "
-            + careContexts);
+        "updateCareContextStatus: abhaAddress: " + abhaAddress + " careContexts: " + careContexts);
   }
 
   /**

--- a/src/main/java/in/nha/abdm/wrapper/v3/database/mongo/services/RequestLogV3Service.java
+++ b/src/main/java/in/nha/abdm/wrapper/v3/database/mongo/services/RequestLogV3Service.java
@@ -479,7 +479,7 @@ public class RequestLogV3Service {
   public void setDiscoverResponse(
       DiscoverRequest discoverRequest,
       OnDiscoverV3Request onDiscoverV3Request,
-      String patientReference) {
+      String abhaAddress) {
     if (Objects.isNull(discoverRequest)) {
       return;
     }
@@ -494,8 +494,7 @@ public class RequestLogV3Service {
     newRecord.setHipId(discoverRequest.getHipId());
     newRecord.setCreatedOn(Utils.getCurrentDateTime());
     newRecord.setLastUpdated(Utils.getCurrentDateTime());
-    newRecord.setAbhaAddress(
-        patientService.getAbhaAddress(patientReference, discoverRequest.getHipId()));
+    newRecord.setAbhaAddress(abhaAddress);
     mongoTemplate.save(newRecord);
   }
 

--- a/src/main/java/in/nha/abdm/wrapper/v3/hip/hrp/discover/DiscoveryV3Service.java
+++ b/src/main/java/in/nha/abdm/wrapper/v3/hip/hrp/discover/DiscoveryV3Service.java
@@ -120,6 +120,7 @@ public class DiscoveryV3Service implements DiscoveryV3Interface {
           () ->
               onDiscoverRequest(
                   discoverRequest,
+                  hipPatient.getAbhaAddress(),
                   hipPatient.getPatientReference(),
                   hipPatient.getPatientDisplay(),
                   hipPatient.getCareContexts(),
@@ -164,6 +165,7 @@ public class DiscoveryV3Service implements DiscoveryV3Interface {
 
       onDiscoverRequest(
           discoverRequest,
+          patient.getAbhaAddress(),
           patient.getPatientReference(),
           patient.getPatientDisplay(),
           unlinkedCareContexts,
@@ -221,6 +223,7 @@ public class DiscoveryV3Service implements DiscoveryV3Interface {
 
     onDiscoverRequest(
         discoverRequest,
+        patient.getAbhaAddress(),
         patient.getPatientReference(),
         patient.getPatientDisplay(),
         unlinkedCareContexts,
@@ -240,6 +243,7 @@ public class DiscoveryV3Service implements DiscoveryV3Interface {
    */
   private void onDiscoverRequest(
       DiscoverRequest discoverRequest,
+      String abhaAddress,
       String patientReference,
       String display,
       List<CareContext> discoveredCareContexts,
@@ -297,7 +301,7 @@ public class DiscoveryV3Service implements DiscoveryV3Interface {
           discoverRequest, onDiscoverV3Request, patientReference);
       log.info("Updating the careContexts into patient");
       patientV3Service.updateCareContext(
-          patientReference, discoveredCareContexts, discoverRequest.getHipId());
+          abhaAddress, patientReference, discoveredCareContexts, discoverRequest.getHipId());
     } catch (WebClientResponseException.BadRequest ex) {
       Object error = BadRequestHandler.getError(ex);
       log.error("HTTP error {}: {}", ex.getStatusCode(), error);

--- a/src/main/java/in/nha/abdm/wrapper/v3/hip/hrp/discover/DiscoveryV3Service.java
+++ b/src/main/java/in/nha/abdm/wrapper/v3/hip/hrp/discover/DiscoveryV3Service.java
@@ -297,8 +297,7 @@ public class DiscoveryV3Service implements DiscoveryV3Interface {
                   discoverRequest.getHipId(),
                   UUID.randomUUID().toString()));
       log.info(onDiscoverPath + " : onDiscoverCall: " + responseEntity.getStatusCode());
-      requestLogV3Service.setDiscoverResponse(
-          discoverRequest, onDiscoverV3Request, patientReference);
+      requestLogV3Service.setDiscoverResponse(discoverRequest, onDiscoverV3Request, abhaAddress);
       log.info("Updating the careContexts into patient");
       patientV3Service.updateCareContext(
           abhaAddress, patientReference, discoveredCareContexts, discoverRequest.getHipId());


### PR DESCRIPTION
Bug:
While searching for abhaAddress in the discovery flow using patientReference, the MongoDB is throwing an error because of multiple patients with the same patientReference.
Since the abha address is already present with us, using the same to avoid the edge case as well as unwanted DB call